### PR TITLE
refactor: cache DSN, redis backend, healthcheck host, hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 Only full releases are listed — pre-release changes are included
 in the next full version entry.
 
+## [Unreleased]
+
+### Added
+
+- `--healthcheck-host` CLI option (defaults to `127.0.0.1`) — previously bound to `0.0.0.0` unconditionally
+- `HttpClientProtocol`, `ListenerProtocol`, `TransportProtocol` are now context managers (`__enter__`/`__exit__`) with a required `close()` method — scheduler closes listener/transport (and their HTTP clients) cleanly on shutdown
+- Per-scheduler `cache_limit` config option — caps the number of entries kept in cache (keeps the N most recent by `grabbed_at`); unbounded when unset
+- `--cache-dsn` CLI flag (default `file:`) — cache backend is now configured on the command line via a URL-style DSN (`file:` persists at `~/.feedforbot/`, `file:///custom/path` uses a custom directory, `memory:` is in-process). Designed to scale to future backends (e.g. `redis://host:6379/0`) without proliferating flags
+- `RedisCache` backend + `redis://…` / `rediss://…` / `unix://…` DSN schemes — shared cache suitable for multi-instance deployments and docker-compose setups. Ships with the `cli` extra (`pip install feedforbot[cli]`) and the GHCR Docker image. The `redis` package is an **optional** dependency — `RedisCache(...)` raises a clear `ImportError` when it isn't installed, so core installs (`pip install feedforbot`) stay minimal
+
+### Changed
+
+- **Breaking:** healthcheck endpoint now responds only at `/health` (previously matched every path) — Docker/Kubernetes probes configured against `/` must be updated
+- **Breaking:** YAML config is now a top-level list of listener+transport entries; the `cache:` and `schedulers:` wrapper keys have been removed. CLI positional argument renamed from `CONFIGURATION` to `SCHEDULERS_FILE`. Cache backend selection moved from `cache.type` in the YAML to the new `--cache-dsn` CLI flag.
+- **Breaking:** `CacheProtocol` redesigned around `is_populated` / `known_ids` / `add(*articles)` / `trim(limit)` (previously `read` / `write` / `is_populated`). `FilesCache` on-disk schema is now `[{"id", "grabbed_at"}]` (no title/url/text). Files written by earlier versions are detected on load, deleted, and treated as a first-run (no spam on upgrade). Custom cache implementations must be updated.
+
+### Fixed
+
+- `FilesCache` writes atomically (tempfile + `os.replace`) — no more corrupted cache on crash/power loss mid-write
+- `FilesCache` tolerates corrupt/invalid cache files — logs a warning, deletes the file and treats it as a first-run instead of propagating to Sentry
+- `FilesCache` no longer grows unbounded — use the new `cache_limit` scheduler option to cap retention
+- `HttpClient.post` raises `HttpResponseError` on non-JSON or non-object payloads (e.g. HTML error pages from Telegram API proxies) instead of leaking `JSONDecodeError`
+- Telegram default and custom templates now HTML-escape article fields (title/text/etc.) — prevents Telegram API rejecting messages with `&`, `<`, `>` in content
+- Config with empty `schedulers: []` is now rejected at parse time instead of crashing with `ValueError` in `ThreadPoolExecutor`
+- `RSSListener` skips individual malformed feed entries (missing `summary`/`title`) with a warning instead of failing the whole tick
+- Telegram bot token masking now covers error-path log lines (`http_error:`) — token could previously leak via `str(exc)` when httpx included the URL in connection errors
+- HTTP 429 flood-wait responses are now retried after the `Retry-After` delay (capped by `max_retry_after`, default 60s) instead of failing the send immediately — Telegram rate-limit bursts self-heal
+- CLI graceful shutdown: `shutdown_start` / `shutdown_complete` are logged on SIGTERM/SIGINT, `CancelledError` is no longer reported as a crash, a second signal forces an immediate `loop.stop()` escape hatch, and Windows (no POSIX signals) falls back to `KeyboardInterrupt` without raising
+
 ## [4.0.0] — 2026-04-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -9,21 +9,34 @@ FeedForBot
 
 Monitors RSS/Atom feeds on a cron schedule and forwards new entries
 to Telegram. Supports multiple feeds, Jinja2 message templates,
-file-based caching to avoid duplicate sends, and optional Sentry
-integration for error tracking.
+pluggable caching (files, in-memory, Redis) to avoid duplicate
+sends, and optional Sentry integration for error tracking.
 
 Features
 --------
 
 - **Multiple feeds** — run any number of listener/transport pairs,
   each with its own cron schedule
-- **Jinja2 templates** — full control over message formatting
-  with access to article fields (`{{ TITLE }}`, `{{ URL }}`,
-  `{{ TEXT }}`, `{{ CATEGORIES }}`, `{{ AUTHORS }}`, etc.)
-- **Caching** — file-based (`~/.feedforbot/`) or in-memory; first
-  run populates the cache silently to avoid flooding the channel
+- **Jinja2 templates** — full control over message formatting with
+  access to article fields (`{{ TITLE }}`, `{{ URL }}`, `{{ TEXT }}`,
+  `{{ CATEGORIES }}`, `{{ AUTHORS }}`, etc.). Templates run in a
+  sandbox with HTML autoescape, so article fields with `&`, `<`, `>`
+  are safe by default
+- **Pluggable cache** — files (`~/.feedforbot/`), in-memory, or
+  Redis (shared across instances), selected via `--cache-dsn`;
+  first run populates the cache silently to avoid flooding the
+  channel. Optional `cache_limit` caps retention per scheduler
+- **Built-in healthcheck** — optional HTTP endpoint at `/health`
+  for Docker/Kubernetes probes
+- **Resilient delivery** — Telegram `429 flood-wait` responses are
+  retried automatically after `Retry-After`; malformed feed entries
+  are skipped with a warning instead of failing the whole tick
+- **Graceful shutdown** — `SIGTERM` / `SIGINT` drain in-flight ticks
+  and close HTTP/Redis/file handles cleanly (second signal forces
+  immediate exit)
 - **Sentry integration** — optional error tracking via `sentry-sdk`
-- **Docker ready** — multi-arch images on GHCR and Docker Hub
+- **Docker ready** — multi-arch images on GHCR and Docker Hub,
+  runs as non-root (`appuser`)
 - **Protocol-driven** — extend with custom listeners, transports,
   and cache backends by implementing simple protocols
 
@@ -95,49 +108,46 @@ asyncio.run(main())
 
 ### CLI with YAML config
 
-Create a `config.yml`:
+Create a `schedulers.yml` — a top-level list of listener+transport entries:
 
 ```yaml
 ---
-cache:
-  type: 'files'
-schedulers:
-  - rule: '*/5 * * * *'
-    listener:
-      type: 'rss'
-      params:
-        url: 'https://habr.com/ru/rss/all/all/?fl=ru'
-    transport:
-      type: 'telegram_bot'
-      params:
-        token: '123456789:AAAAAAAAAA-BBBB-CCCCCCCCCCCC-DDDDDD'
-        to: '@tmfeed'
-        template: |-
-          <b>{{ TITLE }}</b> #habr
-          {{ ID }}
-          <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
-          <b>Author</b>: <a href="https://habr.com/users/{{ AUTHORS[0] }}">{{ AUTHORS[0] }}</a>
-  - listener:
-      type: 'rss'
-      params:
-        url: 'http://www.opennet.ru/opennews/opennews_all.rss'
-    transport:
-      type: 'telegram_bot'
-      params:
-        token: '123456789:AAAAAAAAAA-BBBB-CCCCCCCCCCCC-DDDDDD'
-        to: '@tmfeed'
-        disable_web_page_preview: yes
-        template: |-
-          <b>{{ TITLE }}</b> #opennet
-          {{ URL }}
+- rule: '*/5 * * * *'
+  listener:
+    type: 'rss'
+    params:
+      url: 'https://habr.com/ru/rss/all/all/?fl=ru'
+  transport:
+    type: 'telegram_bot'
+    params:
+      token: '123456789:AAAAAAAAAA-BBBB-CCCCCCCCCCCC-DDDDDD'
+      to: '@tmfeed'
+      template: |-
+        <b>{{ TITLE }}</b> #habr
+        {{ ID }}
+        <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
+        <b>Author</b>: <a href="https://habr.com/users/{{ AUTHORS[0] }}">{{ AUTHORS[0] }}</a>
+- listener:
+    type: 'rss'
+    params:
+      url: 'http://www.opennet.ru/opennews/opennews_all.rss'
+  transport:
+    type: 'telegram_bot'
+    params:
+      token: '123456789:AAAAAAAAAA-BBBB-CCCCCCCCCCCC-DDDDDD'
+      to: '@tmfeed'
+      disable_web_page_preview: yes
+      template: |-
+        <b>{{ TITLE }}</b> #opennet
+        {{ URL }}
 
-          {{ TEXT }}
+        {{ TEXT }}
 ```
 
 Run:
 
 ```commandline
-feedforbot --verbose config.yml
+feedforbot --verbose schedulers.yml
 ```
 
 On the first run the cache is populated without sending messages,
@@ -145,18 +155,34 @@ so existing feed entries won't flood the channel.
 
 #### Config reference
 
+Each list entry supports:
+
 | Key | Description |
 |-----|-------------|
-| `cache.type` | `files` (persistent, default dir `~/.feedforbot/`) or `in_memory` |
-| `cache.params` | Backend-specific options (e.g. custom path for `files`) |
-| `schedulers[].rule` | Cron expression (e.g. `*/5 * * * *`) |
-| `schedulers[].listener.type` | `rss` |
-| `schedulers[].listener.params.url` | Feed URL |
-| `schedulers[].transport.type` | `telegram_bot` |
-| `schedulers[].transport.params.token` | Telegram Bot API token |
-| `schedulers[].transport.params.to` | Chat ID or `@channel` name |
-| `schedulers[].transport.params.template` | Jinja2 template string (HTML parse mode) |
-| `schedulers[].transport.params.disable_web_page_preview` | `true` / `false` |
+| `rule` | Cron expression (e.g. `*/5 * * * *`), optional — defaults to `* * * * *` (every minute) |
+| `cache_limit` | Max cache entries kept (keeps N most recent by `grabbed_at`), optional — unbounded when unset |
+| `listener.type` | `rss` |
+| `listener.params.url` | Feed URL |
+| `transport.type` | `telegram_bot` |
+| `transport.params.token` | Telegram Bot API token |
+| `transport.params.to` | Chat ID or `@channel` name |
+| `transport.params.template` | Jinja2 template string (HTML parse mode), optional — defaults to `{{ TITLE }}\n\n{{ TEXT }}\n\n{{ URL }}` |
+| `transport.params.disable_web_page_preview` | `true` / `false`, optional — defaults to `false` |
+| `transport.params.disable_notification` | `true` / `false`, optional — defaults to `false` |
+
+An empty top-level list is rejected at parse time.
+
+#### Cache CLI flag
+
+Cache backend selection is a CLI concern (not part of the schedulers file).
+`--cache-dsn` takes a URL-style DSN; scheme selects the backend:
+
+| DSN | Backend |
+|-----|---------|
+| `file:` (default) | Persistent on-disk cache at `~/.feedforbot/` |
+| `file:///custom/path` | Persistent on-disk cache at a custom directory |
+| `memory:` | In-process cache (lost on restart) |
+| `redis://host:6379/0` | Shared Redis cache (requires `feedforbot[cli]` or `pip install redis`). Useful for multi-instance deployments and docker-compose setups where a separate Redis container holds state. |
 
 #### Template variables
 
@@ -170,6 +196,24 @@ All fields from `ArticleModel` are available in uppercase:
 | `{{ TEXT }}` | Entry summary / description |
 | `{{ CATEGORIES }}` | List of tags/categories |
 | `{{ AUTHORS }}` | List of authors |
+| `{{ GRABBED_AT }}` | Timestamp when the entry was fetched (UTC) |
+
+Templates render in a Jinja2 sandbox with HTML autoescape enabled
+(messages use `parse_mode=HTML`). Article fields containing `&`,
+`<`, `>` are escaped automatically — you don't need to guard against
+Telegram rejecting the message for invalid HTML.
+
+#### CLI options
+
+| Option | Description |
+|--------|-------------|
+| `SCHEDULERS_FILE` | Positional — path to the YAML schedulers config |
+| `-v`, `--verbose` | Repeat for more detail (`-v` INFO, `-vv` DEBUG, `-vvv` NOTSET) |
+| `-V`, `--version` | Print version and exit |
+| `--cache-dsn` | Cache backend DSN (see table above); default `file:` |
+| `--sentry` | Sentry DSN for error reporting |
+| `--healthcheck-port` | Port for the HTTP healthcheck server (disabled when unset) |
+| `--healthcheck-host` | Bind host for the healthcheck server; default `127.0.0.1`. Use `0.0.0.0` inside containers when the port is exposed to the host |
 
 Docker
 ------
@@ -178,13 +222,13 @@ Images are published to both **GHCR** and **Docker Hub** on every
 release. Tags follow semver: `latest`, `4`, `4.0`, `4.0.0`.
 
 ```commandline
-docker run -v $(pwd)/config.yml:/config.yml \
-  ghcr.io/shpaker/feedforbot --verbose /config.yml
+docker run -v $(pwd)/schedulers.yml:/schedulers.yml \
+  ghcr.io/shpaker/feedforbot --verbose /schedulers.yml
 ```
 
 ```commandline
-docker run -v $(pwd)/config.yml:/config.yml \
-  shpaker/feedforbot --verbose /config.yml
+docker run -v $(pwd)/schedulers.yml:/schedulers.yml \
+  shpaker/feedforbot --verbose /schedulers.yml
 ```
 
 The container runs as a non-root user (`appuser`).
@@ -194,11 +238,17 @@ Healthcheck
 
 The CLI includes a built-in HTTP healthcheck server. Pass
 `--healthcheck-port` to expose a lightweight endpoint that responds
-with `200 OK` on every request:
+with `200 OK` at `/health` (other paths return `404 Not Found`):
 
 ```commandline
-feedforbot --healthcheck-port 8080 --verbose config.yml
+feedforbot --healthcheck-port 8080 --verbose schedulers.yml
 ```
+
+The server binds to `127.0.0.1` by default. Pass
+`--healthcheck-host 0.0.0.0` when the port must be reachable from
+outside the container (e.g. for an external probe); the in-container
+Docker `HEALTHCHECK` below works either way since it queries
+`localhost` from the same network namespace.
 
 Useful for container orchestrators (Docker `HEALTHCHECK`, Kubernetes
 liveness probes, etc.):
@@ -208,13 +258,61 @@ liveness probes, etc.):
 services:
   feedforbot:
     image: ghcr.io/shpaker/feedforbot
-    command: ["--healthcheck-port", "8080", "--verbose", "/config.yml"]
+    command: ["--healthcheck-port", "8080", "--verbose", "/schedulers.yml"]
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
       timeout: 5s
       retries: 3
 ```
+
+Docker Compose with Redis
+-------------------------
+
+For multi-instance deployments or when you want cache state to
+survive container rebuilds without a host volume for JSON files,
+run `feedforbot` alongside a Redis container and point
+`--cache-dsn` at it:
+
+```yaml
+# docker-compose.yml
+services:
+  redis:
+    image: redis:7-alpine
+    restart: always
+    volumes:
+      - ./redis_data:/data
+    command: ["redis-server", "--save", "60", "1", "--appendonly", "no"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+
+  feedforbot:
+    image: ghcr.io/shpaker/feedforbot
+    restart: always
+    depends_on:
+      redis:
+        condition: service_healthy
+    volumes:
+      - ./schedulers.yml:/schedulers.yml:ro
+    command: >
+      -v
+      --cache-dsn redis://redis:6379/0
+      --healthcheck-port 8080
+      /schedulers.yml
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+```
+
+A working Ansible playbook that deploys this layout is in
+[tmfeed/deploy.yml](tmfeed/deploy.yml).
 
 License
 -------

--- a/feedforbot/__init__.py
+++ b/feedforbot/__init__.py
@@ -1,5 +1,5 @@
 from feedforbot.__version__ import __title__, __version__
-from feedforbot.cache import FilesCache, InMemoryCache
+from feedforbot.cache import FilesCache, InMemoryCache, RedisCache
 from feedforbot.listeners import RSSListener
 from feedforbot.scheduler import Scheduler
 from feedforbot.transports import TelegramBotTransport
@@ -16,6 +16,7 @@ __all__ = (
     "InMemoryCache",
     "ListenerProtocol",
     "RSSListener",
+    "RedisCache",
     "Scheduler",
     "TelegramBotTransport",
     "TransportProtocol",

--- a/feedforbot/cache.py
+++ b/feedforbot/cache.py
@@ -1,7 +1,11 @@
+import contextlib
 import hashlib
 import json
-from collections.abc import Iterable
+import os
+import tempfile
+from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 from feedforbot.__version__ import __title__
 from feedforbot.article import ArticleModel
@@ -9,7 +13,16 @@ from feedforbot.logger import logger
 from feedforbot.types import CacheProtocol
 
 
+try:
+    import redis as _redis
+except ImportError:  # pragma: no cover
+    _redis = None  # type: ignore[assignment]
+
+
 _DEFAULT_FILES_CACHE_DIR = Path.home() / ".feedforbot"
+
+_REDIS_KEY_PREFIX = "feedforbot"
+_REDIS_POPULATED_FIELD = "__populated__"
 
 
 class InMemoryCache(CacheProtocol):
@@ -17,7 +30,7 @@ class InMemoryCache(CacheProtocol):
         self,
         id: str,  # noqa: ARG002
     ) -> None:
-        self._cache: tuple[ArticleModel, ...] = ()
+        self._entries: dict[str, datetime] = {}
         self._populated: bool = False
 
     def __repr__(self) -> str:
@@ -27,17 +40,30 @@ class InMemoryCache(CacheProtocol):
     def is_populated(self) -> bool:
         return self._populated
 
-    def write(
+    @property
+    def known_ids(self) -> set[str]:
+        return set(self._entries.keys())
+
+    def add(
         self,
         *articles: ArticleModel,
     ) -> None:
-        self._cache = articles
+        for article in articles:
+            self._entries[article.id] = article.grabbed_at
         self._populated = True
 
-    def read(
+    def trim(
         self,
-    ) -> Iterable[ArticleModel]:
-        return self._cache
+        limit: int,
+    ) -> None:
+        if limit <= 0 or len(self._entries) <= limit:
+            return
+        kept = sorted(
+            self._entries.items(),
+            key=lambda item: item[1],
+            reverse=True,
+        )[:limit]
+        self._entries = dict(kept)
 
 
 class FilesCache(CacheProtocol):
@@ -50,63 +76,179 @@ class FilesCache(CacheProtocol):
         self.data_dir = data_dir.resolve()
         sha = hashlib.sha256(id.encode("utf-8")).hexdigest()
         self.cache_path = self.data_dir / f"{sha}.json"
+        self._entries: dict[str, datetime] | None = None
 
     def __repr__(self) -> str:
         return f"<{__title__}.{self.__class__.__name__}: {self.cache_path}>"
 
     @property
     def is_populated(self) -> bool:
+        if not self.cache_path.exists():
+            return False
+        self._load()
         return self.cache_path.exists()
 
-    def write(
+    @property
+    def known_ids(self) -> set[str]:
+        self._load()
+        assert self._entries is not None  # noqa: S101
+        return set(self._entries.keys())
+
+    def add(
         self,
         *articles: ArticleModel,
     ) -> None:
-        self._ensure_data_dir()
-        with open(
-            self.cache_path,
-            mode="w",
-        ) as fh:
-            fh.write(
-                json.dumps(
-                    [article.model_dump(mode="json") for article in articles],
-                    indent=2,
-                    sort_keys=True,
-                ),
-            )
-        logger.debug(
-            "cache_write: path=%s articles=%d",
-            self.cache_path,
-            len(articles),
-        )
+        self._load()
+        assert self._entries is not None  # noqa: S101
+        for article in articles:
+            self._entries[article.id] = article.grabbed_at
+        self._flush()
 
-    def read(
+    def trim(
         self,
-    ) -> Iterable[ArticleModel]:
+        limit: int,
+    ) -> None:
+        self._load()
+        assert self._entries is not None  # noqa: S101
+        if limit <= 0 or len(self._entries) <= limit:
+            return
+        kept = sorted(
+            self._entries.items(),
+            key=lambda item: item[1],
+            reverse=True,
+        )[:limit]
+        self._entries = dict(kept)
+        self._flush()
+
+    def _load(self) -> None:
+        if self._entries is not None:
+            return
         try:
             with open(self.cache_path) as fh:
                 contents = fh.read()
         except FileNotFoundError:
-            logger.debug(
-                "cache_read: path=%s found=false",
-                self.cache_path,
-            )
-            return ()
+            self._entries = {}
+            return
         if not contents:
-            logger.debug(
-                "cache_read: path=%s empty=true",
+            self._entries = {}
+            return
+        try:
+            raw = json.loads(contents)
+            entries: dict[str, datetime] = {}
+            for item in raw:
+                aid = item["id"]
+                entries[aid] = datetime.fromisoformat(item["grabbed_at"])
+            self._entries = entries
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "cache_read_corrupt: path=%s — deleting to recover",
                 self.cache_path,
             )
-            return ()
-        articles = tuple(ArticleModel(**data) for data in json.loads(contents))
-        logger.debug(
-            "cache_read: path=%s found=true articles=%d",
-            self.cache_path,
-            len(articles),
+            with contextlib.suppress(OSError):
+                self.cache_path.unlink()
+            self._entries = {}
+
+    def _flush(self) -> None:
+        assert self._entries is not None  # noqa: S101
+        self._ensure_data_dir()
+        payload = json.dumps(
+            [
+                {"id": aid, "grabbed_at": ts.isoformat()}
+                for aid, ts in sorted(
+                    self._entries.items(),
+                    key=lambda item: (item[1], item[0]),
+                )
+            ],
+            indent=2,
         )
-        return articles
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=f"{self.cache_path.name}.",
+            suffix=".tmp",
+            dir=self.data_dir,
+        )
+        tmp = Path(tmp_path)
+        try:
+            with os.fdopen(fd, mode="w") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            tmp.replace(self.cache_path)
+        except BaseException:
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            raise
+        logger.debug(
+            "cache_write: path=%s entries=%d",
+            self.cache_path,
+            len(self._entries),
+        )
 
     def _ensure_data_dir(
         self,
     ) -> None:
         self.data_dir.mkdir(parents=True, exist_ok=True)
+
+
+class RedisCache(CacheProtocol):
+    def __init__(
+        self,
+        id: str,
+        url: str,
+    ) -> None:
+        if _redis is None:
+            raise ImportError(  # noqa: TRY003
+                "feedforbot: RedisCache requires the `redis` package. "
+                "Install with `pip install feedforbot[cli]` "
+                "or `pip install redis`.",
+            )
+        self.id = id
+        self.url = url
+        sha = hashlib.sha256(id.encode("utf-8")).hexdigest()
+        self._key = f"{_REDIS_KEY_PREFIX}:{sha}"
+        self._client = _redis.Redis.from_url(
+            url,
+            decode_responses=True,
+        )
+
+    def __repr__(self) -> str:
+        return f"<{__title__}.{self.__class__.__name__}: {self._key}>"
+
+    @property
+    def is_populated(self) -> bool:
+        return bool(
+            self._client.hexists(self._key, _REDIS_POPULATED_FIELD),
+        )
+
+    @property
+    def known_ids(self) -> set[str]:
+        fields = cast("list[str]", self._client.hkeys(self._key))
+        return {f for f in fields if f != _REDIS_POPULATED_FIELD}
+
+    def add(
+        self,
+        *articles: ArticleModel,
+    ) -> None:
+        mapping: dict[str, str] = {
+            article.id: article.grabbed_at.isoformat() for article in articles
+        }
+        mapping[_REDIS_POPULATED_FIELD] = "1"
+        self._client.hset(self._key, mapping=mapping)
+
+    def trim(
+        self,
+        limit: int,
+    ) -> None:
+        if limit <= 0:
+            return
+        raw = cast("dict[str, str]", self._client.hgetall(self._key))
+        raw.pop(_REDIS_POPULATED_FIELD, None)
+        if len(raw) <= limit:
+            return
+        entries = sorted(
+            raw.items(),
+            key=lambda item: datetime.fromisoformat(item[1]),
+            reverse=True,
+        )
+        to_remove = [aid for aid, _ in entries[limit:]]
+        if to_remove:
+            self._client.hdel(self._key, *to_remove)

--- a/feedforbot/cache.py
+++ b/feedforbot/cache.py
@@ -172,7 +172,7 @@ class FilesCache(CacheProtocol):
                 fh.write(payload)
                 fh.flush()
                 os.fsync(fh.fileno())
-            tmp.replace(self.cache_path)
+            os.replace(tmp, self.cache_path)  # noqa: PTH105
         except BaseException:
             with contextlib.suppress(OSError):
                 tmp.unlink()

--- a/feedforbot/cli/app.py
+++ b/feedforbot/cli/app.py
@@ -1,12 +1,16 @@
 import asyncio
+import contextlib
 import signal
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from urllib.parse import urlparse
 
 import click
 import sentry_sdk
 from click import Context, argument, command, option, pass_context, types
 
+from feedforbot import CacheProtocol, FilesCache, InMemoryCache, RedisCache
 from feedforbot.__version__ import __title__
 from feedforbot.__version__ import __version__ as _version
 from feedforbot.cli.config import read_config
@@ -24,9 +28,46 @@ _VERBOSITY_LEVELS = (
 )
 
 
+def _build_cache_factory(
+    dsn: str,
+) -> Callable[[str], CacheProtocol]:
+    parsed = urlparse(dsn)
+    scheme = parsed.scheme
+
+    if scheme == "memory":
+
+        def _memory_factory(cache_id: str) -> CacheProtocol:
+            return InMemoryCache(id=cache_id)
+
+        return _memory_factory
+
+    if scheme == "file":
+        data_dir = Path(parsed.path) if parsed.path else None
+
+        def _file_factory(cache_id: str) -> CacheProtocol:
+            if data_dir is None:
+                return FilesCache(id=cache_id)
+            return FilesCache(id=cache_id, data_dir=data_dir)
+
+        return _file_factory
+
+    if scheme in ("redis", "rediss", "unix"):
+
+        def _redis_factory(cache_id: str) -> CacheProtocol:
+            return RedisCache(id=cache_id, url=dsn)
+
+        return _redis_factory
+
+    raise click.BadParameter(  # noqa: TRY003
+        f"unknown cache scheme {scheme!r} in {dsn!r}. "
+        "Supported: `memory:`, `file:[///path]`, `redis://…`.",
+        param_hint="'--cache-dsn'",
+    )
+
+
 @command()
 @argument(
-    "configuration",
+    "schedulers_file",
     required=True,
     type=types.Path(
         exists=True,
@@ -51,6 +92,19 @@ _VERBOSITY_LEVELS = (
     help="Show script version and exit.",
 )
 @option(
+    "--cache-dsn",
+    type=click.STRING,
+    default="file:",
+    show_default=True,
+    help=(
+        "Cache backend DSN. `file:` persists at ~/.feedforbot/; "
+        "`file:///custom/path` uses a custom directory; "
+        "`memory:` is in-process (lost on restart); "
+        "`redis://host:6379/0` uses Redis (requires the `cli` extra "
+        "or `pip install redis`)."
+    ),
+)
+@option(
     "--sentry",
     type=click.STRING,
     default=None,
@@ -62,15 +116,27 @@ _VERBOSITY_LEVELS = (
     type=click.INT,
     default=None,
     show_default=True,
-    help="Port for HTTP healthcheck endpoint.",
+    help="Port for HTTP healthcheck endpoint (served at /health).",
+)
+@option(
+    "--healthcheck-host",
+    type=click.STRING,
+    default="127.0.0.1",
+    show_default=True,
+    help=(
+        "Host for HTTP healthcheck endpoint. "
+        "Use 0.0.0.0 to bind on all interfaces (e.g. in containers)."
+    ),
 )
 @pass_context
 def main(
     ctx: Context,
-    configuration: Path,
+    schedulers_file: Path,
     verbose: int,
+    cache_dsn: str,
     sentry: str | None,
     healthcheck_port: int | None,
+    healthcheck_host: str,
 ) -> None:
     """
     Bot for forwarding updates from RSS/Atom feeds
@@ -88,11 +154,13 @@ def main(
         verbose = len(_VERBOSITY_LEVELS) - 1
     log_level = _VERBOSITY_LEVELS[verbose]
     configure_logging(log_level=log_level)
-    schedulers = read_config(configuration)
+    cache_factory = _build_cache_factory(cache_dsn)
+    schedulers = read_config(schedulers_file, cache_factory=cache_factory)
     logger.info(
-        "config_loaded: path=%s schedulers=%d",
-        configuration,
+        "config_loaded: path=%s schedulers=%d cache=%s",
+        schedulers_file,
         len(schedulers),
+        cache_dsn,
     )
 
     async def _run_forever() -> None:
@@ -106,35 +174,50 @@ def main(
         if healthcheck_port is not None:
             tasks.append(
                 asyncio.create_task(
-                    run_healthcheck_server(healthcheck_port),
+                    run_healthcheck_server(
+                        healthcheck_port,
+                        host=healthcheck_host,
+                    ),
                 ),
             )
 
+        shutting_down = False
+
         def _shutdown(sig: signal.Signals) -> None:
-            logger.info("shutdown: signal=%s", sig.name)
+            nonlocal shutting_down
+            if shutting_down:
+                logger.warning(
+                    "shutdown_force: signal=%s — aborting in-flight work",
+                    sig.name,
+                )
+                loop.stop()
+                return
+            shutting_down = True
+            logger.info("shutdown_start: signal=%s", sig.name)
             for scheduler in schedulers:
                 scheduler.stop()
             for task in tasks:
                 task.cancel()
 
-        loop = asyncio.get_running_loop()
         for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(
-                sig,
-                _shutdown,
-                sig,
-            )
+            # Windows: add_signal_handler unsupported — falls back to
+            # KeyboardInterrupt from asyncio.run
+            with contextlib.suppress(NotImplementedError):
+                loop.add_signal_handler(sig, _shutdown, sig)
 
         results = await asyncio.gather(
             *tasks,
             return_exceptions=True,
         )
         for i, result in enumerate(results):
+            if isinstance(result, asyncio.CancelledError):
+                continue
             if isinstance(result, Exception):
                 logger.error(
                     "task_crashed: index=%d error=%s",
                     i,
                     result,
                 )
+        logger.info("shutdown_complete")
 
     asyncio.run(_run_forever())

--- a/feedforbot/cli/config.py
+++ b/feedforbot/cli/config.py
@@ -11,32 +11,21 @@ else:
         pass
 
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, TypeAdapter
 from yaml import safe_load
 
 from feedforbot import (
     CacheProtocol,
-    FilesCache,
-    InMemoryCache,
     ListenerProtocol,
     RSSListener,
     Scheduler,
     TelegramBotTransport,
     TransportProtocol,
 )
-
-
-class _CacheTypes(StrEnum):
-    IN_MEMORY = "in_memory"
-    FILES = "files"
-
-
-class _CacheConfigMapping(Enum):
-    IN_MEMORY = InMemoryCache
-    FILES = FilesCache
 
 
 class _ListenerTypes(StrEnum):
@@ -67,26 +56,21 @@ class _TransportConfigModel(_ConfigEntryModel):
     type: _TransportTypes
 
 
-class _CacheConfigModel(_ConfigEntryModel):
-    type: _CacheTypes
-
-
 class _SchedulerConfigModel(BaseModel):
     rule: str = "* * * * *"
+    cache_limit: int | None = None
     listener: _ListenerConfigModel
     transport: _TransportConfigModel
 
 
-class _ConfigModel(BaseModel):
-    cache: _CacheConfigModel
-    schedulers: tuple[_SchedulerConfigModel, ...]
-
-
-def _cache_from_config(
-    config: _ConfigModel,
-) -> type[CacheProtocol]:
-    name = config.cache.type.name
-    return _CacheConfigMapping[name].value
+_SchedulersAdapter: TypeAdapter[tuple[_SchedulerConfigModel, ...]] = (
+    TypeAdapter(
+        Annotated[
+            tuple[_SchedulerConfigModel, ...],
+            Field(min_length=1),
+        ],
+    )
+)
 
 
 def _listener_from_config(
@@ -106,38 +90,39 @@ def _transport_from_config(
 def _make_scheduler_from_config(
     config: _SchedulerConfigModel,
     *,
-    cache_cls: Any,
+    cache_factory: Callable[[str], CacheProtocol],
 ) -> Scheduler:
     transport_cls = _transport_from_config(config)
     listener_cls = _listener_from_config(config)
     listener = listener_cls(**config.listener.params)
     transport = transport_cls(**config.transport.params)
+    cache_id = (
+        f"{config.listener.type.value}"
+        f":{config.listener.params.get('url', '')}"
+        f"|{config.transport.type.value}"
+        f":{config.transport.params.get('to', '')}"
+    )
     return Scheduler(
         config.rule,
         listener=listener,
         transport=transport,
-        cache=cache_cls(
-            id=(
-                f"{config.listener.type.value}"
-                f":{config.listener.params.get('url', '')}"
-                f"|{config.transport.type.value}"
-                f":{config.transport.params.get('to', '')}"
-            ),
-        ),
+        cache=cache_factory(cache_id),
+        cache_limit=config.cache_limit,
     )
 
 
 def read_config(
     path: Path,
+    *,
+    cache_factory: Callable[[str], CacheProtocol],
 ) -> tuple[Scheduler, ...]:
     with path.open(encoding="utf-8", mode="r") as fh:
         data = safe_load(fh.read())
-    config = _ConfigModel(**data)
-    cache_cls = _cache_from_config(config)
+    schedulers_config = _SchedulersAdapter.validate_python(data)
     return tuple(
         _make_scheduler_from_config(
             scheduler_config,
-            cache_cls=cache_cls,
+            cache_factory=cache_factory,
         )
-        for scheduler_config in config.schedulers
+        for scheduler_config in schedulers_config
     )

--- a/feedforbot/cli/healthcheck.py
+++ b/feedforbot/cli/healthcheck.py
@@ -4,17 +4,34 @@ from http import HTTPStatus
 from feedforbot.logger import logger
 
 
+_HEALTH_PATH = "/health"
+
+
 async def run_healthcheck_server(
     port: int,
-    host: str = "0.0.0.0",  # noqa: S104
+    host: str = "127.0.0.1",
 ) -> None:
     async def _handle(
-        reader: asyncio.StreamReader,  # noqa: ARG001
+        reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
-        body = b"ok"
+        request_line = await reader.readline()
+        parts = request_line.decode("latin-1", errors="replace").split()
+        match parts:
+            case [_, target, *_]:
+                path = target.split("?", 1)[0]
+            case _:
+                path = ""
+
+        if path == _HEALTH_PATH:
+            status = HTTPStatus.OK
+            body = b"ok"
+        else:
+            status = HTTPStatus.NOT_FOUND
+            body = b"not found"
+
         header = (
-            f"HTTP/1.1 {HTTPStatus.OK.value} {HTTPStatus.OK.phrase}\r\n"
+            f"HTTP/1.1 {status.value} {status.phrase}\r\n"
             f"Content-Type: text/plain\r\n"
             f"Content-Length: {len(body)}\r\n"
             f"\r\n"

--- a/feedforbot/http_client.py
+++ b/feedforbot/http_client.py
@@ -1,5 +1,7 @@
+import json
 import time
 from collections.abc import Sequence
+from types import TracebackType
 from typing import Any
 
 import httpx
@@ -16,7 +18,18 @@ _DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
 _DEFAULT_MAX_RETRIES = 3
 _DEFAULT_BACKOFF_BASE = 1.0
 _DEFAULT_BACKOFF_FACTOR = 2.0
+_DEFAULT_MAX_RETRY_AFTER = 60.0
 _SERVER_ERROR_THRESHOLD = 500
+_RATE_LIMIT_STATUS = 429
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    if value is None:
+        return None
+    try:
+        return max(0.0, float(value.strip()))
+    except ValueError:
+        return None
 
 
 class _LoggingHTTPTransport(
@@ -77,7 +90,7 @@ class _LoggingHTTPTransport(
                 url,
                 host,
                 duration_ms,
-                exc,
+                self._mask(f"{type(exc).__name__}: {exc}"),
             )
             raise
 
@@ -110,6 +123,7 @@ class HttpClient(HttpClientProtocol):
         max_retries: int = _DEFAULT_MAX_RETRIES,
         backoff_base: float = _DEFAULT_BACKOFF_BASE,
         backoff_factor: float = _DEFAULT_BACKOFF_FACTOR,
+        max_retry_after: float = _DEFAULT_MAX_RETRY_AFTER,
     ) -> None:
         transport = _LoggingHTTPTransport(
             sensitive_values=sensitive_values,
@@ -122,6 +136,7 @@ class HttpClient(HttpClientProtocol):
         self._max_retries = max_retries
         self._backoff_base = backoff_base
         self._backoff_factor = backoff_factor
+        self._max_retry_after = max_retry_after
 
     def _request(
         self,
@@ -139,7 +154,26 @@ class HttpClient(HttpClientProtocol):
                 )
                 response.raise_for_status()
             except httpx.HTTPStatusError as exc:
-                if exc.response.status_code < _SERVER_ERROR_THRESHOLD:
+                status = exc.response.status_code
+                if status == _RATE_LIMIT_STATUS:
+                    last_exc = exc
+                    retry_after = _parse_retry_after(
+                        exc.response.headers.get("Retry-After"),
+                    )
+                    if (
+                        retry_after is None
+                        or retry_after > self._max_retry_after
+                        or attempt >= self._max_retries - 1
+                    ):
+                        break
+                    logger.info(
+                        "http_rate_limited: attempt=%d retry_after=%.1fs",
+                        attempt + 1,
+                        retry_after,
+                    )
+                    time.sleep(retry_after)
+                    continue
+                if status < _SERVER_ERROR_THRESHOLD:
                     raise HttpResponseError from exc
                 last_exc = exc
             except httpx.HTTPError as exc:
@@ -169,7 +203,29 @@ class HttpClient(HttpClientProtocol):
         data: dict[str, Any],
     ) -> dict[str, Any]:
         response = self._request("POST", url, json=data)
-        return response.json()
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            logger.error(
+                "http_response_non_json: host=%s status=%d",
+                response.request.url.host,
+                response.status_code,
+            )
+            raise HttpResponseError from exc
+        if not isinstance(payload, dict):
+            raise HttpResponseError
+        return payload
 
     def close(self) -> None:
         self._client.close()
+
+    def __enter__(self) -> "HttpClient":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()

--- a/feedforbot/listeners.py
+++ b/feedforbot/listeners.py
@@ -1,4 +1,5 @@
 from email.utils import parsedate_to_datetime
+from types import TracebackType
 from typing import TYPE_CHECKING
 
 from bs4 import BeautifulSoup
@@ -31,6 +32,20 @@ class RSSListener(ListenerProtocol):
 
     def __repr__(self) -> str:
         return f"<{__title__}.{self.__class__.__name__}: {self.url}>"
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> "RSSListener":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def _parse_entry(
         self,
@@ -68,15 +83,27 @@ class RSSListener(ListenerProtocol):
         except HttpClientError as exc:
             raise ListenerReceiveError from exc
         parsed = parse(response)
-        articles = tuple(self._parse_entry(entry) for entry in parsed.entries)
+        articles: list[ArticleModel] = []
+        skipped = 0
+        for entry in parsed.entries:
+            try:
+                articles.append(self._parse_entry(entry))
+            except Exception:  # noqa: BLE001
+                skipped += 1
+                logger.warning(
+                    "listener_entry_skipped: %s id=%s",
+                    self,
+                    entry.get("id") or entry.get("link"),
+                )
         logger.info(
-            "listener_receive: %s entries=%d",
+            "listener_receive: %s entries=%d skipped=%d",
             self,
             len(articles),
+            skipped,
         )
         logger.debug(
             "listener_receive_ids: %s ids=%s",
             self,
             [a.id for a in articles],
         )
-        return articles
+        return tuple(articles)

--- a/feedforbot/scheduler.py
+++ b/feedforbot/scheduler.py
@@ -7,7 +7,6 @@ import structlog
 from croniter import croniter
 from epyxid import XID
 
-from feedforbot.article import ArticleModel
 from feedforbot.cache import InMemoryCache
 from feedforbot.exceptions import ListenerReceiveError
 from feedforbot.logger import logger
@@ -27,11 +26,13 @@ class Scheduler:
         listener: ListenerProtocol,
         transport: TransportProtocol,
         cache: CacheProtocol | None = None,
+        cache_limit: int | None = None,
     ) -> None:
         self.cron_rule = cron_rule
         self.listener = listener
         self.transport = transport
         self.cache = cache or InMemoryCache(id=listener.source_id)
+        self.cache_limit = cache_limit
         self._stop_event = threading.Event()
 
     def _tick(
@@ -77,19 +78,18 @@ class Scheduler:
                 self.listener,
                 len(articles),
             )
-            self.cache.write(*articles)
+            self.cache.add(*articles)
+            self._maybe_trim()
             return
-        cached_set = set(self.cache.read())
-        to_send = tuple(
-            article for article in articles if article not in cached_set
-        )
+        known = self.cache.known_ids
+        to_send = tuple(a for a in articles if a.id not in known)
         if not to_send:
             logger.debug(
                 "scheduler_no_new_articles: %s",
                 self.listener,
             )
-            merged = self._merge_articles(cached_set, articles)
-            self.cache.write(*merged)
+            self.cache.add(*articles)
+            self._maybe_trim()
             return
         _oldest = datetime.min.replace(tzinfo=timezone.utc)
         to_send = tuple(
@@ -112,12 +112,14 @@ class Scheduler:
                 self.listener,
                 failed_ids,
             )
-        failed_set = set(failed)
-        cacheable = tuple(
-            article for article in articles if article not in failed_set
-        )
-        merged = self._merge_articles(cached_set, cacheable)
-        self.cache.write(*merged)
+        failed_id_set = {a.id for a in failed}
+        cacheable = tuple(a for a in articles if a.id not in failed_id_set)
+        self.cache.add(*cacheable)
+        self._maybe_trim()
+
+    def _maybe_trim(self) -> None:
+        if self.cache_limit is not None:
+            self.cache.trim(self.cache_limit)
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -132,13 +134,14 @@ class Scheduler:
         )
         self._stop_event.clear()
         cron = croniter(self.cron_rule)
-        while not self._stop_event.is_set():
-            delay = cron.get_next(float) - time.time()
-            if delay > 0 and self._stop_event.wait(
-                timeout=delay,
-            ):
-                break
-            self._tick()
+        with self.listener, self.transport:
+            while not self._stop_event.is_set():
+                delay = cron.get_next(float) - time.time()
+                if delay > 0 and self._stop_event.wait(
+                    timeout=delay,
+                ):
+                    break
+                self._tick()
 
     async def arun(self) -> None:
         logger.info(
@@ -150,24 +153,14 @@ class Scheduler:
         )
         self._stop_event.clear()
         cron = croniter(self.cron_rule)
-        while not self._stop_event.is_set():
-            delay = cron.get_next(float) - time.time()
-            if delay > 0:
-                try:
-                    await asyncio.sleep(delay)
-                except asyncio.CancelledError:
-                    return
-            if self._stop_event.is_set():
-                break
-            await asyncio.to_thread(self._tick)
-
-    @staticmethod
-    def _merge_articles(
-        cached: set[ArticleModel],
-        *groups: tuple[ArticleModel, ...],
-    ) -> tuple[ArticleModel, ...]:
-        seen: dict[str, ArticleModel] = {a.id: a for a in cached}
-        for group in groups:
-            for article in group:
-                seen[article.id] = article
-        return tuple(seen.values())
+        with self.listener, self.transport:
+            while not self._stop_event.is_set():
+                delay = cron.get_next(float) - time.time()
+                if delay > 0:
+                    try:
+                        await asyncio.sleep(delay)
+                    except asyncio.CancelledError:
+                        return
+                if self._stop_event.is_set():
+                    break
+                await asyncio.to_thread(self._tick)

--- a/feedforbot/transports.py
+++ b/feedforbot/transports.py
@@ -1,3 +1,6 @@
+from types import TracebackType
+
+from jinja2 import select_autoescape
 from jinja2.sandbox import SandboxedEnvironment
 
 from feedforbot.__version__ import __title__
@@ -12,7 +15,12 @@ from feedforbot.sentry import capture_exception, new_scope
 from feedforbot.types import HttpClientProtocol, TransportProtocol
 
 
-_SANDBOX = SandboxedEnvironment()
+_SANDBOX = SandboxedEnvironment(
+    autoescape=select_autoescape(
+        default=True,
+        default_for_string=True,
+    ),
+)
 _DEFAULT_TEMPLATE_STR = "{{ TITLE }}\n\n{{ TEXT }}\n\n{{ URL }}"
 _DEFAULT_MESSAGE_TEMPLATE = _SANDBOX.from_string(
     _DEFAULT_TEMPLATE_STR,
@@ -44,6 +52,20 @@ class TelegramBotTransport(TransportProtocol):
 
     def __repr__(self) -> str:
         return f"<{__title__}.{self.__class__.__name__}: {self._to}>"
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> "TelegramBotTransport":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def _send_article(
         self,

--- a/feedforbot/types.py
+++ b/feedforbot/types.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from types import TracebackType
 from typing import Any, Protocol
 
 from feedforbot.article import ArticleModel
@@ -19,6 +19,17 @@ class HttpClientProtocol(
         data: dict[str, Any],
     ) -> dict[str, Any]: ...
 
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "HttpClientProtocol": ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+
 
 class CacheProtocol(
     Protocol,
@@ -26,14 +37,18 @@ class CacheProtocol(
     @property
     def is_populated(self) -> bool: ...
 
-    def write(
+    @property
+    def known_ids(self) -> set[str]: ...
+
+    def add(
         self,
         *articles: ArticleModel,
     ) -> None: ...
 
-    def read(
+    def trim(
         self,
-    ) -> Iterable[ArticleModel]: ...
+        limit: int,
+    ) -> None: ...
 
 
 class ListenerProtocol(
@@ -45,6 +60,17 @@ class ListenerProtocol(
         self,
     ) -> tuple[ArticleModel, ...]: ...
 
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "ListenerProtocol": ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+
 
 class TransportProtocol(
     Protocol,
@@ -53,3 +79,14 @@ class TransportProtocol(
         self,
         *articles: ArticleModel,
     ) -> list[ArticleModel]: ...
+
+    def close(self) -> None: ...
+
+    def __enter__(self) -> "TransportProtocol": ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 cli = [
   "click>=8.1,<9",
   "pyyaml>=6.0,<7",
+  "redis>=5,<6",
   "sentry-sdk>=2.0,<3",
   "structlog>=24.1",
 ]
@@ -33,6 +34,7 @@ Repository = "https://github.com/shpaker/feedforbot"
 [dependency-groups]
 dev = [
   "feedforbot[cli]",
+  "fakeredis>=2,<3",
   "freezegun>=1.5",
   "mypy>=1.15,<2",
   "pytest>=8.3",

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,9 +1,11 @@
+from collections.abc import Callable
 from pathlib import Path
 
 from pydantic import ValidationError
 from pytest import raises
 
 from feedforbot import (
+    CacheProtocol,
     FilesCache,
     InMemoryCache,
     RSSListener,
@@ -11,6 +13,19 @@ from feedforbot import (
     TelegramBotTransport,
 )
 from feedforbot.cli.config import read_config
+
+
+def _in_memory_factory(cache_id: str) -> CacheProtocol:
+    return InMemoryCache(id=cache_id)
+
+
+def _files_factory(
+    data_dir: Path,
+) -> Callable[[str], CacheProtocol]:
+    def _factory(cache_id: str) -> CacheProtocol:
+        return FilesCache(id=cache_id, data_dir=data_dir)
+
+    return _factory
 
 
 def _write_config(
@@ -26,21 +41,18 @@ def test_minimal_config(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: in_memory
-schedulers:
-  - listener:
-      type: rss
-      params:
-        url: https://example.com/feed
-    transport:
-      type: telegram_bot
-      params:
-        token: fake-token
-        to: "@chan"
+- listener:
+    type: rss
+    params:
+      url: https://example.com/feed
+  transport:
+    type: telegram_bot
+    params:
+      token: fake-token
+      to: "@chan"
 """,
     )
-    schedulers = read_config(path)
+    schedulers = read_config(path, cache_factory=_in_memory_factory)
     assert len(schedulers) == 1
     s = schedulers[0]
     assert isinstance(s, Scheduler)
@@ -54,44 +66,43 @@ def test_files_cache(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: files
-schedulers:
-  - listener:
-      type: rss
-      params:
-        url: https://example.com/feed
-    transport:
-      type: telegram_bot
-      params:
-        token: fake-token
-        to: "@chan"
+- listener:
+    type: rss
+    params:
+      url: https://example.com/feed
+  transport:
+    type: telegram_bot
+    params:
+      token: fake-token
+      to: "@chan"
 """,
     )
-    schedulers = read_config(path)
-    assert isinstance(schedulers[0].cache, FilesCache)
+    schedulers = read_config(
+        path,
+        cache_factory=_files_factory(tmp_path),
+    )
+    cache = schedulers[0].cache
+    assert isinstance(cache, FilesCache)
+    assert cache.data_dir == tmp_path.resolve()
 
 
 def test_custom_cron_rule(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: in_memory
-schedulers:
-  - rule: "*/5 * * * *"
-    listener:
-      type: rss
-      params:
-        url: https://example.com/feed
-    transport:
-      type: telegram_bot
-      params:
-        token: fake-token
-        to: "@chan"
+- rule: "*/5 * * * *"
+  listener:
+    type: rss
+    params:
+      url: https://example.com/feed
+  transport:
+    type: telegram_bot
+    params:
+      token: fake-token
+      to: "@chan"
 """,
     )
-    schedulers = read_config(path)
+    schedulers = read_config(path, cache_factory=_in_memory_factory)
     assert schedulers[0].cron_rule == "*/5 * * * *"
 
 
@@ -99,84 +110,60 @@ def test_multiple_schedulers(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: in_memory
-schedulers:
-  - listener:
-      type: rss
-      params:
-        url: https://example.com/feed1
-    transport:
-      type: telegram_bot
-      params:
-        token: token1
-        to: "@chan1"
-  - listener:
-      type: rss
-      params:
-        url: https://example.com/feed2
-    transport:
-      type: telegram_bot
-      params:
-        token: token2
-        to: "@chan2"
+- listener:
+    type: rss
+    params:
+      url: https://example.com/feed1
+  transport:
+    type: telegram_bot
+    params:
+      token: token1
+      to: "@chan1"
+- listener:
+    type: rss
+    params:
+      url: https://example.com/feed2
+  transport:
+    type: telegram_bot
+    params:
+      token: token2
+      to: "@chan2"
 """,
     )
-    schedulers = read_config(path)
+    schedulers = read_config(path, cache_factory=_in_memory_factory)
     expected = 2
     assert len(schedulers) == expected
-
-
-def test_invalid_cache_type(tmp_path: Path) -> None:
-    path = _write_config(
-        tmp_path,
-        """
-cache:
-  type: redis
-schedulers:
-  - listener:
-      type: rss
-      params:
-        url: https://example.com/feed
-    transport:
-      type: telegram_bot
-      params:
-        token: fake
-        to: "@chan"
-""",
-    )
-    with raises(ValidationError):
-        read_config(path)
 
 
 def test_invalid_listener_type(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: in_memory
-schedulers:
-  - listener:
-      type: unknown
-      params:
-        url: https://example.com
-    transport:
-      type: telegram_bot
-      params:
-        token: fake
-        to: "@chan"
+- listener:
+    type: unknown
+    params:
+      url: https://example.com
+  transport:
+    type: telegram_bot
+    params:
+      token: fake
+      to: "@chan"
 """,
     )
     with raises(ValidationError):
-        read_config(path)
+        read_config(path, cache_factory=_in_memory_factory)
 
 
-def test_cache_id_is_stable(tmp_path: Path) -> None:
+def test_empty_config_rejected(tmp_path: Path) -> None:
+    path = _write_config(tmp_path, "[]\n")
+    with raises(ValidationError):
+        read_config(path, cache_factory=_in_memory_factory)
+
+
+def test_invalid_root_is_not_list(tmp_path: Path) -> None:
     path = _write_config(
         tmp_path,
         """
-cache:
-  type: in_memory
 schedulers:
   - listener:
       type: rss
@@ -185,12 +172,31 @@ schedulers:
     transport:
       type: telegram_bot
       params:
-        token: fake-token
+        token: fake
         to: "@chan"
 """,
     )
-    s1 = read_config(path)
-    s2 = read_config(path)
+    with raises(ValidationError):
+        read_config(path, cache_factory=_in_memory_factory)
+
+
+def test_cache_id_is_stable(tmp_path: Path) -> None:
+    path = _write_config(
+        tmp_path,
+        """
+- listener:
+    type: rss
+    params:
+      url: https://example.com/feed
+  transport:
+    type: telegram_bot
+    params:
+      token: fake-token
+      to: "@chan"
+""",
+    )
+    s1 = read_config(path, cache_factory=_in_memory_factory)
+    s2 = read_config(path, cache_factory=_in_memory_factory)
     c1 = s1[0].cache
     c2 = s2[0].cache
     assert isinstance(c1, InMemoryCache)

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -22,7 +22,7 @@ _CONFIG = """
 """
 
 
-def _spawn(config: Path) -> subprocess.Popen[str]:
+def _spawn(config: Path) -> subprocess.Popen[bytes]:
     return subprocess.Popen(  # noqa: S603
         [
             sys.executable,
@@ -35,41 +35,47 @@ def _spawn(config: Path) -> subprocess.Popen[str]:
         ],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
-        text=True,
         start_new_session=True,
     )
 
 
 def _wait_for(
-    proc: subprocess.Popen[str],
+    proc: subprocess.Popen[bytes],
     needle: str,
     timeout: float,
 ) -> str:
     deadline = time.monotonic() + timeout
-    buf: list[str] = []
+    buf = bytearray()
     assert proc.stdout is not None
-    os.set_blocking(proc.stdout.fileno(), False)
+    fd = proc.stdout.fileno()
+    os.set_blocking(fd, False)
     while time.monotonic() < deadline:
         try:
-            chunk = proc.stdout.read()
+            chunk = os.read(fd, 4096)
         except BlockingIOError:
-            chunk = None
+            chunk = b""
         if chunk:
-            buf.append(chunk)
-            if needle in "".join(buf):
-                return "".join(buf)
+            buf.extend(chunk)
+            if needle in buf.decode("utf-8", errors="replace"):
+                return buf.decode("utf-8", errors="replace")
         time.sleep(0.05)
-    return "".join(buf)
+    return buf.decode("utf-8", errors="replace")
 
 
-def _drain(proc: subprocess.Popen[str]) -> str:
+def _drain(proc: subprocess.Popen[bytes]) -> str:
     if proc.stdout is None:
         return ""
-    try:
-        remainder = proc.stdout.read()
-    except (BlockingIOError, ValueError):
-        remainder = None
-    return remainder or ""
+    fd = proc.stdout.fileno()
+    data = bytearray()
+    while True:
+        try:
+            chunk = os.read(fd, 4096)
+        except (BlockingIOError, OSError):
+            break
+        if not chunk:
+            break
+        data.extend(chunk)
+    return data.decode("utf-8", errors="replace")
 
 
 @mark.skipif(

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -1,0 +1,124 @@
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from pytest import mark
+
+
+_CONFIG = """
+- rule: "0 0 1 1 *"
+  listener:
+    type: rss
+    params:
+      url: http://127.0.0.1:1/feed
+  transport:
+    type: telegram_bot
+    params:
+      token: fake-token
+      to: "@chan"
+"""
+
+
+def _spawn(config: Path) -> subprocess.Popen[str]:
+    return subprocess.Popen(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "feedforbot",
+            "-v",
+            "--cache-dsn",
+            "memory:",
+            str(config),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def _wait_for(
+    proc: subprocess.Popen[str],
+    needle: str,
+    timeout: float,
+) -> str:
+    deadline = time.monotonic() + timeout
+    buf: list[str] = []
+    assert proc.stdout is not None
+    os.set_blocking(proc.stdout.fileno(), False)
+    while time.monotonic() < deadline:
+        try:
+            chunk = proc.stdout.read()
+        except BlockingIOError:
+            chunk = None
+        if chunk:
+            buf.append(chunk)
+            if needle in "".join(buf):
+                return "".join(buf)
+        time.sleep(0.05)
+    return "".join(buf)
+
+
+@mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX signal handling only",
+)
+def test_sigterm_triggers_graceful_shutdown(tmp_path: Path) -> None:
+    config = tmp_path / "config.yml"
+    config.write_text(_CONFIG)
+
+    proc = _spawn(config)
+    try:
+        start_out = _wait_for(proc, "scheduler_start", timeout=15.0)
+        assert "scheduler_start" in start_out, start_out
+
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise
+
+        assert proc.returncode == 0, (start_out, proc.returncode)
+        remainder = proc.stdout.read() if proc.stdout else ""
+        combined = start_out + (remainder or "")
+        assert "shutdown_start" in combined, combined
+        assert "shutdown_complete" in combined, combined
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)
+
+
+@mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX signal handling only",
+)
+def test_double_sigint_forces_shutdown(tmp_path: Path) -> None:
+    config = tmp_path / "config.yml"
+    config.write_text(_CONFIG)
+
+    proc = _spawn(config)
+    try:
+        start_out = _wait_for(proc, "scheduler_start", timeout=15.0)
+        assert "scheduler_start" in start_out, start_out
+
+        proc.send_signal(signal.SIGINT)
+        time.sleep(0.1)
+        proc.send_signal(signal.SIGINT)
+        try:
+            proc.wait(timeout=10.0)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            raise
+
+        remainder = proc.stdout.read() if proc.stdout else ""
+        combined = start_out + (remainder or "")
+        assert "shutdown_start" in combined, combined
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=5.0)

--- a/tests/cli/test_shutdown.py
+++ b/tests/cli/test_shutdown.py
@@ -62,6 +62,16 @@ def _wait_for(
     return "".join(buf)
 
 
+def _drain(proc: subprocess.Popen[str]) -> str:
+    if proc.stdout is None:
+        return ""
+    try:
+        remainder = proc.stdout.read()
+    except (BlockingIOError, ValueError):
+        remainder = None
+    return remainder or ""
+
+
 @mark.skipif(
     sys.platform == "win32",
     reason="POSIX signal handling only",
@@ -83,8 +93,7 @@ def test_sigterm_triggers_graceful_shutdown(tmp_path: Path) -> None:
             raise
 
         assert proc.returncode == 0, (start_out, proc.returncode)
-        remainder = proc.stdout.read() if proc.stdout else ""
-        combined = start_out + (remainder or "")
+        combined = start_out + _drain(proc)
         assert "shutdown_start" in combined, combined
         assert "shutdown_complete" in combined, combined
     finally:
@@ -115,8 +124,7 @@ def test_double_sigint_forces_shutdown(tmp_path: Path) -> None:
             proc.kill()
             raise
 
-        remainder = proc.stdout.read() if proc.stdout else ""
-        combined = start_out + (remainder or "")
+        combined = start_out + _drain(proc)
         assert "shutdown_start" in combined, combined
     finally:
         if proc.poll() is None:

--- a/tests/listeners/test_rss.py
+++ b/tests/listeners/test_rss.py
@@ -22,6 +22,7 @@ class FakeHttpClient:
     ) -> None:
         self._get_response = get_response
         self._raise_on_get = raise_on_get
+        self.closed = False
 
     def get(self, url: str) -> bytes:  # noqa: ARG002
         if self._raise_on_get is not None:
@@ -35,6 +36,15 @@ class FakeHttpClient:
         data: dict[str, Any],
     ) -> dict[str, Any]:
         raise NotImplementedError
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> "FakeHttpClient":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
 
 
 @freeze_time("2012-01-14 12:00:01+00:00")
@@ -138,3 +148,42 @@ def test_repr() -> None:
     listener = RSSListener(url=_TESTING_URL, http_client=http)
     assert _TESTING_URL in repr(listener)
     assert "RSSListener" in repr(listener)
+
+
+_MIXED_FEED = b"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+<title>t</title><link>http://x</link><description>d</description>
+<item>
+  <title>Good</title>
+  <link>https://example.com/good</link>
+  <description>ok body</description>
+  <guid>https://example.com/good</guid>
+</item>
+<item>
+  <link>https://example.com/bad</link>
+  <guid>https://example.com/bad</guid>
+</item>
+</channel></rss>
+"""
+
+
+def test_receive_skips_malformed_entries() -> None:
+    http = FakeHttpClient(get_response=_MIXED_FEED)
+    listener = RSSListener(url=_TESTING_URL, http_client=http)
+    feed = listener.receive()
+    assert len(feed) == 1
+    assert feed[0].title == "Good"
+
+
+def test_close_closes_http_client() -> None:
+    http = FakeHttpClient()
+    listener = RSSListener(url=_TESTING_URL, http_client=http)
+    listener.close()
+    assert http.closed is True
+
+
+def test_context_manager_closes_http_client() -> None:
+    http = FakeHttpClient()
+    with RSSListener(url=_TESTING_URL, http_client=http):
+        pass
+    assert http.closed is True

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,15 @@
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+import fakeredis
+import pytest
+from pytest import raises
+
+from feedforbot import cache as cache_module
 from feedforbot.article import ArticleModel
-from feedforbot.cache import FilesCache, InMemoryCache
+from feedforbot.cache import FilesCache, InMemoryCache, RedisCache
 
 
 def _article(**kwargs: Any) -> ArticleModel:
@@ -17,32 +23,57 @@ def _article(**kwargs: Any) -> ArticleModel:
     return ArticleModel(**defaults)
 
 
+_T0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+
 class TestInMemoryCache:
     def test_not_populated_initially(self) -> None:
         cache = InMemoryCache(id="test")
         assert not cache.is_populated
 
-    def test_read_returns_empty_when_not_populated(
-        self,
-    ) -> None:
+    def test_known_ids_empty_when_not_populated(self) -> None:
         cache = InMemoryCache(id="test")
-        assert tuple(cache.read()) == ()
+        assert cache.known_ids == set()
 
-    def test_write_and_read(self) -> None:
+    def test_add_populates_and_known_ids(self) -> None:
         cache = InMemoryCache(id="test")
-        a1 = _article(id="1")
-        a2 = _article(id="2")
-        cache.write(a1, a2)
+        cache.add(_article(id="1"), _article(id="2"))
         assert cache.is_populated
-        assert tuple(cache.read()) == (a1, a2)
+        assert cache.known_ids == {"1", "2"}
 
-    def test_write_overwrites(self) -> None:
+    def test_add_accumulates(self) -> None:
         cache = InMemoryCache(id="test")
-        a1 = _article(id="1")
-        a2 = _article(id="2")
-        cache.write(a1)
-        cache.write(a2)
-        assert tuple(cache.read()) == (a2,)
+        cache.add(_article(id="1"))
+        cache.add(_article(id="2"))
+        assert cache.known_ids == {"1", "2"}
+
+    def test_add_updates_grabbed_at_for_existing_id(self) -> None:
+        cache = InMemoryCache(id="test")
+        cache.add(_article(id="1", grabbed_at=_T0))
+        cache.add(_article(id="1", grabbed_at=_T0 + timedelta(days=1)))
+        assert cache.known_ids == {"1"}
+
+    def test_trim_keeps_most_recent(self) -> None:
+        cache = InMemoryCache(id="test")
+        cache.add(
+            _article(id="old", grabbed_at=_T0),
+            _article(id="mid", grabbed_at=_T0 + timedelta(days=1)),
+            _article(id="new", grabbed_at=_T0 + timedelta(days=2)),
+        )
+        cache.trim(2)
+        assert cache.known_ids == {"mid", "new"}
+
+    def test_trim_noop_when_under_limit(self) -> None:
+        cache = InMemoryCache(id="test")
+        cache.add(_article(id="1"), _article(id="2"))
+        cache.trim(10)
+        assert cache.known_ids == {"1", "2"}
+
+    def test_trim_zero_is_noop(self) -> None:
+        cache = InMemoryCache(id="test")
+        cache.add(_article(id="1"))
+        cache.trim(0)
+        assert cache.known_ids == {"1"}
 
     def test_repr(self) -> None:
         cache = InMemoryCache(id="test")
@@ -57,48 +88,54 @@ class TestFilesCache:
         cache = FilesCache(id="test", data_dir=tmp_path)
         assert not cache.is_populated
 
-    def test_read_returns_empty_when_not_populated(
+    def test_known_ids_empty_when_not_populated(
         self,
         tmp_path: Path,
     ) -> None:
         cache = FilesCache(id="test", data_dir=tmp_path)
-        assert tuple(cache.read()) == ()
+        assert cache.known_ids == set()
 
-    def test_write_and_read(
+    def test_add_and_known_ids(
         self,
         tmp_path: Path,
     ) -> None:
         cache = FilesCache(id="test", data_dir=tmp_path)
-        a1 = _article(id="1")
-        a2 = _article(id="2")
-        cache.write(a1, a2)
+        cache.add(_article(id="1"), _article(id="2"))
         assert cache.is_populated
-        result = tuple(cache.read())
-        expected = 2
-        assert len(result) == expected
-        assert result[0].id == "1"
-        assert result[1].id == "2"
+        assert cache.known_ids == {"1", "2"}
 
-    def test_write_creates_json_file(
+    def test_add_persists_across_instances(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        c1 = FilesCache(id="test", data_dir=tmp_path)
+        c1.add(_article(id="1"), _article(id="2"))
+        c2 = FilesCache(id="test", data_dir=tmp_path)
+        assert c2.known_ids == {"1", "2"}
+
+    def test_write_creates_json_file_with_slim_schema(
         self,
         tmp_path: Path,
     ) -> None:
         cache = FilesCache(id="test", data_dir=tmp_path)
-        cache.write(_article(id="1"))
-        assert cache.cache_path.exists()
+        cache.add(_article(id="1", title="big title", text="huge body"))
         data = json.loads(cache.cache_path.read_text())
         assert len(data) == 1
+        assert set(data[0].keys()) == {"id", "grabbed_at"}
 
-    def test_write_overwrites(
+    def test_trim_keeps_most_recent(
         self,
         tmp_path: Path,
     ) -> None:
         cache = FilesCache(id="test", data_dir=tmp_path)
-        cache.write(_article(id="1"), _article(id="2"))
-        cache.write(_article(id="3"))
-        result = tuple(cache.read())
-        assert len(result) == 1
-        assert result[0].id == "3"
+        cache.add(
+            _article(id="old", grabbed_at=_T0),
+            _article(id="mid", grabbed_at=_T0 + timedelta(days=1)),
+            _article(id="new", grabbed_at=_T0 + timedelta(days=2)),
+        )
+        cache.trim(2)
+        reloaded = FilesCache(id="test", data_dir=tmp_path)
+        assert reloaded.known_ids == {"mid", "new"}
 
     def test_read_handles_empty_file(
         self,
@@ -107,7 +144,44 @@ class TestFilesCache:
         cache = FilesCache(id="test", data_dir=tmp_path)
         cache.cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache.cache_path.write_text("")
-        assert tuple(cache.read()) == ()
+        assert cache.known_ids == set()
+
+    def test_read_handles_corrupt_json(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache = FilesCache(id="test", data_dir=tmp_path)
+        cache.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache.cache_path.write_text("{not valid json")
+        assert cache.known_ids == set()
+
+    def test_corrupt_file_is_deleted_and_treated_as_first_run(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache = FilesCache(id="test", data_dir=tmp_path)
+        cache.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache.cache_path.write_text("{not json")
+        assert cache.is_populated is False
+        assert not cache.cache_path.exists()
+
+    def test_old_schema_is_deleted_and_treated_as_first_run(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache = FilesCache(id="test", data_dir=tmp_path)
+        cache.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        old_payload = [
+            {
+                "id": "1",
+                "title": "legacy",
+                "url": "https://example.com/1",
+                "text": "body",
+            },
+        ]
+        cache.cache_path.write_text(json.dumps(old_payload))
+        assert cache.is_populated is False
+        assert not cache.cache_path.exists()
 
     def test_creates_data_dir(
         self,
@@ -115,7 +189,7 @@ class TestFilesCache:
     ) -> None:
         data_dir = tmp_path / "sub" / "dir"
         cache = FilesCache(id="test", data_dir=data_dir)
-        cache.write(_article(id="1"))
+        cache.add(_article(id="1"))
         assert data_dir.exists()
 
     def test_deterministic_path(
@@ -141,3 +215,173 @@ class TestFilesCache:
         cache = FilesCache(id="test", data_dir=tmp_path)
         assert "FilesCache" in repr(cache)
         assert str(tmp_path) in repr(cache)
+
+    def test_write_is_atomic_no_stray_tmp_files(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        cache = FilesCache(id="test", data_dir=tmp_path)
+        cache.add(_article(id="1"))
+        cache.add(_article(id="2"))
+        leftovers = [
+            p for p in tmp_path.iterdir() if p.name != cache.cache_path.name
+        ]
+        assert leftovers == []
+
+    def test_write_does_not_leave_partial_file_on_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: Any,
+    ) -> None:
+        import os as os_mod  # noqa: PLC0415
+
+        cache = FilesCache(id="test", data_dir=tmp_path)
+        cache.add(_article(id="original"))
+        original_content = cache.cache_path.read_text()
+
+        def _boom(src: str, dst: str) -> None:  # noqa: ARG001
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os_mod, "replace", _boom)
+        with raises(OSError, match="disk full"):
+            cache.add(_article(id="replacement"))
+
+        assert cache.cache_path.read_text() == original_content
+        leftovers = [
+            p for p in tmp_path.iterdir() if p.name != cache.cache_path.name
+        ]
+        assert leftovers == []
+
+
+class TestRedisCache:
+    @pytest.fixture
+    def fake_server(
+        self,
+        monkeypatch: Any,
+    ) -> fakeredis.FakeServer:
+        server = fakeredis.FakeServer()
+
+        def _fake_from_url(
+            url: str,  # noqa: ARG001
+            **_: Any,
+        ) -> fakeredis.FakeStrictRedis:
+            return fakeredis.FakeStrictRedis(
+                server=server,
+                decode_responses=True,
+            )
+
+        monkeypatch.setattr(
+            cache_module._redis.Redis,  # type: ignore[attr-defined] # noqa: SLF001
+            "from_url",
+            staticmethod(_fake_from_url),
+        )
+        return server
+
+    def test_not_populated_initially(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        assert not cache.is_populated
+
+    def test_known_ids_empty_when_not_populated(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        assert cache.known_ids == set()
+
+    def test_add_populates_and_known_ids(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(_article(id="1"), _article(id="2"))
+        assert cache.is_populated
+        assert cache.known_ids == {"1", "2"}
+
+    def test_add_accumulates(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(_article(id="1"))
+        cache.add(_article(id="2"))
+        assert cache.known_ids == {"1", "2"}
+
+    def test_add_persists_across_instances(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        c1 = RedisCache(id="test", url="redis://localhost:6379/0")
+        c1.add(_article(id="1"), _article(id="2"))
+        c2 = RedisCache(id="test", url="redis://localhost:6379/0")
+        assert c2.known_ids == {"1", "2"}
+        assert c2.is_populated
+
+    def test_populated_field_excluded_from_known_ids(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(_article(id="1"))
+        assert "__populated__" not in cache.known_ids
+
+    def test_trim_keeps_most_recent(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(
+            _article(id="old", grabbed_at=_T0),
+            _article(id="mid", grabbed_at=_T0 + timedelta(days=1)),
+            _article(id="new", grabbed_at=_T0 + timedelta(days=2)),
+        )
+        cache.trim(2)
+        reloaded = RedisCache(id="test", url="redis://localhost:6379/0")
+        assert reloaded.known_ids == {"mid", "new"}
+
+    def test_trim_noop_when_under_limit(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(_article(id="1"), _article(id="2"))
+        cache.trim(10)
+        assert cache.known_ids == {"1", "2"}
+
+    def test_trim_zero_is_noop(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        cache.add(_article(id="1"))
+        cache.trim(0)
+        assert cache.known_ids == {"1"}
+
+    def test_different_ids_different_keys(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        c1 = RedisCache(id="id-a", url="redis://localhost:6379/0")
+        c2 = RedisCache(id="id-b", url="redis://localhost:6379/0")
+        c1.add(_article(id="only-a"))
+        c2.add(_article(id="only-b"))
+        assert c1.known_ids == {"only-a"}
+        assert c2.known_ids == {"only-b"}
+
+    def test_repr(
+        self,
+        fake_server: fakeredis.FakeServer,  # noqa: ARG002
+    ) -> None:
+        cache = RedisCache(id="test", url="redis://localhost:6379/0")
+        assert "RedisCache" in repr(cache)
+        assert "feedforbot:" in repr(cache)
+
+    def test_raises_import_error_when_redis_missing(
+        self,
+        monkeypatch: Any,
+    ) -> None:
+        monkeypatch.setattr(cache_module, "_redis", None)
+        with raises(ImportError, match="RedisCache requires"):
+            RedisCache(id="test", url="redis://localhost:6379/0")

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -231,3 +231,128 @@ def test_retry_exhausted_raises(
     )
     with raises(HttpResponseError):
         client.get(f"{_BASE_URL}/down")
+
+
+def test_post_raises_on_non_json_response(
+    respx_mock: MockRouter,
+) -> None:
+    respx_mock.post(f"{_BASE_URL}/api").respond(
+        status_code=200,
+        content=b"<html>503 backend down</html>",
+        headers={"content-type": "text/html"},
+    )
+    client = _no_retry_client()
+    with raises(HttpResponseError):
+        client.post(
+            f"{_BASE_URL}/api",
+            data={"key": "value"},
+        )
+
+
+def test_masks_token_in_exception_message(
+    respx_mock: MockRouter,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    token = "secret-bot-token-789"
+    url = f"{_BASE_URL}/bot{token}/sendMessage"
+    respx_mock.post(url).mock(
+        side_effect=httpx.ConnectError(
+            f"failed to connect to {url}",
+        ),
+    )
+
+    client = _no_retry_client(sensitive_values=(token,))
+    with (
+        caplog.at_level(logging.INFO, logger="feedforbot"),
+        raises(HttpTransportError),
+    ):
+        client.post(url, data={"chat_id": "1"})
+
+    errors = _messages(caplog, "http_error:")
+    assert len(errors) == 1
+    assert token not in errors[0]
+    assert "***" in errors[0]
+
+
+def test_retry_on_429_with_retry_after_header(
+    respx_mock: MockRouter,
+) -> None:
+    route = respx_mock.post(f"{_BASE_URL}/api")
+    route.side_effect = [
+        httpx.Response(
+            429,
+            headers={"Retry-After": "0"},
+            json={"ok": False},
+        ),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    client = HttpClient(max_retries=3, backoff_base=0.01)
+    result = client.post(f"{_BASE_URL}/api", data={})
+    assert result == {"ok": True}
+    expected_calls = 2
+    assert len(route.calls) == expected_calls
+
+
+def test_429_without_retry_after_gives_up(
+    respx_mock: MockRouter,
+) -> None:
+    route = respx_mock.post(f"{_BASE_URL}/api").respond(
+        status_code=429,
+        json={"ok": False},
+    )
+    client = HttpClient(max_retries=3, backoff_base=0.01)
+    with raises(HttpResponseError):
+        client.post(f"{_BASE_URL}/api", data={})
+    assert len(route.calls) == 1
+
+
+def test_429_retry_after_above_cap_gives_up(
+    respx_mock: MockRouter,
+) -> None:
+    route = respx_mock.post(f"{_BASE_URL}/api").respond(
+        status_code=429,
+        headers={"Retry-After": "300"},
+        json={"ok": False},
+    )
+    client = HttpClient(
+        max_retries=3,
+        backoff_base=0.01,
+        max_retry_after=60.0,
+    )
+    with raises(HttpResponseError):
+        client.post(f"{_BASE_URL}/api", data={})
+    assert len(route.calls) == 1
+
+
+def test_429_exhausts_retries(
+    respx_mock: MockRouter,
+) -> None:
+    route = respx_mock.post(f"{_BASE_URL}/api").respond(
+        status_code=429,
+        headers={"Retry-After": "0"},
+        json={"ok": False},
+    )
+    client = HttpClient(
+        max_retries=2,
+        backoff_base=0.01,
+        max_retry_after=60.0,
+    )
+    with raises(HttpResponseError):
+        client.post(f"{_BASE_URL}/api", data={})
+    expected_calls = 2
+    assert len(route.calls) == expected_calls
+
+
+def test_post_raises_on_non_object_json(
+    respx_mock: MockRouter,
+) -> None:
+    respx_mock.post(f"{_BASE_URL}/api").respond(
+        status_code=200,
+        json=["not", "an", "object"],
+    )
+    client = _no_retry_client()
+    with raises(HttpResponseError):
+        client.post(
+            f"{_BASE_URL}/api",
+            data={"key": "value"},
+        )

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,6 +9,38 @@ from feedforbot.exceptions import ListenerReceiveError
 from feedforbot.scheduler import Scheduler
 
 
+class FakeCache:
+    def __init__(
+        self,
+        cached: Iterable[ArticleModel] | None = None,
+    ) -> None:
+        self._ids: set[str] = set()
+        self._populated = False
+        if cached is not None:
+            self._populated = True
+            for a in cached:
+                self._ids.add(a.id)
+        self.added: list[tuple[ArticleModel, ...]] = []
+        self.trim_calls: list[int] = []
+
+    @property
+    def is_populated(self) -> bool:
+        return self._populated
+
+    @property
+    def known_ids(self) -> set[str]:
+        return set(self._ids)
+
+    def add(self, *articles: ArticleModel) -> None:
+        for a in articles:
+            self._ids.add(a.id)
+        self._populated = True
+        self.added.append(articles)
+
+    def trim(self, limit: int) -> None:
+        self.trim_calls.append(limit)
+
+
 def _article(**kwargs: Any) -> ArticleModel:
     defaults: dict[str, Any] = {
         "id": "1",
@@ -31,11 +63,21 @@ class FakeListener:
     ) -> None:
         self._articles = articles
         self._raise_on_receive = raise_on_receive
+        self.closed = False
 
     def receive(self) -> tuple[ArticleModel, ...]:
         if self._raise_on_receive is not None:
             raise self._raise_on_receive
         return self._articles
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> "FakeListener":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
 
 
 class FakeTransport:
@@ -45,6 +87,7 @@ class FakeTransport:
     ) -> None:
         self._failed = failed or []
         self.sent: list[ArticleModel] = []
+        self.closed = False
 
     def send(
         self,
@@ -53,31 +96,14 @@ class FakeTransport:
         self.sent.extend(articles)
         return self._failed
 
+    def close(self) -> None:
+        self.closed = True
 
-class FakeCache:
-    def __init__(
-        self,
-        cached: Iterable[ArticleModel] | None = None,
-    ) -> None:
-        if cached is None:
-            self._cached: tuple[ArticleModel, ...] = ()
-            self._populated = False
-        else:
-            self._cached = tuple(cached)
-            self._populated = True
-        self.written: list[tuple[ArticleModel, ...]] = []
+    def __enter__(self) -> "FakeTransport":
+        return self
 
-    @property
-    def is_populated(self) -> bool:
-        return self._populated
-
-    def read(self) -> Iterable[ArticleModel]:
-        return self._cached
-
-    def write(self, *articles: ArticleModel) -> None:
-        self._cached = articles
-        self._populated = True
-        self.written.append(articles)
+    def __exit__(self, *_: Any) -> None:
+        self.close()
 
 
 def _make_scheduler(
@@ -85,12 +111,14 @@ def _make_scheduler(
     listener: FakeListener | None = None,
     transport: FakeTransport | None = None,
     cache: FakeCache | None = None,
+    cache_limit: int | None = None,
 ) -> Scheduler:
     return Scheduler(
         "* * * * *",
         listener=listener or FakeListener(),
         transport=transport or FakeTransport(),
         cache=cache,
+        cache_limit=cache_limit,
     )
 
 
@@ -108,8 +136,8 @@ def test_first_run_populates_cache_without_sending() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert transport.sent == []
-    assert len(cache.written) == 1
-    assert cache.written[0] == (a1, a2)
+    assert cache.known_ids == {"1", "2"}
+    assert len(cache.added) == 1
 
 
 def test_sends_new_articles() -> None:
@@ -126,7 +154,7 @@ def test_sends_new_articles() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert transport.sent == [new]
-    assert cache.written[0] == (old, new)
+    assert cache.known_ids == {"old", "new"}
 
 
 def test_no_new_articles_updates_cache() -> None:
@@ -142,8 +170,7 @@ def test_no_new_articles_updates_cache() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert transport.sent == []
-    assert len(cache.written) == 1
-    assert cache.written[0] == (a1,)
+    assert cache.known_ids == {"1"}
 
 
 def test_listener_error_is_handled() -> None:
@@ -160,7 +187,7 @@ def test_listener_error_is_handled() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert transport.sent == []
-    assert cache.written == []
+    assert cache.added == []
 
 
 def test_partial_send_failure_excludes_failed_from_cache() -> None:
@@ -178,10 +205,10 @@ def test_partial_send_failure_excludes_failed_from_cache() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert transport.sent == [a1, a2]
-    written_ids = {a.id for a in cache.written[0]}
-    assert "old" in written_ids
-    assert "a1" in written_ids
-    assert "a2" not in written_ids
+    ids = cache.known_ids
+    assert "old" in ids
+    assert "a1" in ids
+    assert "a2" not in ids
 
 
 def test_all_send_failed_keeps_old_in_cache() -> None:
@@ -199,10 +226,10 @@ def test_all_send_failed_keeps_old_in_cache() -> None:
     scheduler._tick()  # noqa: SLF001
 
     assert set(transport.sent) == {new1, new2}
-    written_ids = {a.id for a in cache.written[0]}
-    assert "old" in written_ids
-    assert "n1" not in written_ids
-    assert "n2" not in written_ids
+    ids = cache.known_ids
+    assert "old" in ids
+    assert "n1" not in ids
+    assert "n2" not in ids
 
 
 def test_reappearing_article_not_resent() -> None:
@@ -281,15 +308,37 @@ async def test_arun_stop() -> None:
     await asyncio.gather(task, stop_task)
 
 
+def test_run_closes_listener_and_transport() -> None:
+    listener = FakeListener(articles=(_article(),))
+    transport = FakeTransport()
+
+    class StopAfterFirstTick(Scheduler):
+        def _tick(self) -> None:
+            super()._tick()
+            self.stop()
+
+    scheduler = StopAfterFirstTick(
+        "* * * * *",
+        listener=listener,
+        transport=transport,
+        cache=FakeCache(cached=None),
+    )
+    scheduler.run()
+
+    assert listener.closed is True
+    assert transport.closed is True
+
+
 def test_tick_survives_unexpected_exception() -> None:
     """Scheduler must not die when _tick_inner raises
     an unexpected exception (e.g. cache/transport bug)."""
 
-    class BrokenCacheOnRead(FakeCache):
-        def read(self) -> Any:
+    class BrokenCacheOnKnownIds(FakeCache):
+        @property
+        def known_ids(self) -> set[str]:
             raise RuntimeError("disk on fire")
 
-    cache = BrokenCacheOnRead(cached=[_article(id="old")])
+    cache = BrokenCacheOnKnownIds(cached=[_article(id="old")])
     transport = FakeTransport()
     scheduler = _make_scheduler(
         listener=FakeListener(articles=(_article(id="old"),)),
@@ -297,11 +346,29 @@ def test_tick_survives_unexpected_exception() -> None:
         cache=cache,
     )
 
-    # First tick hits cache.read() which raises — scheduler
-    # must catch the exception instead of propagating it.
     scheduler._tick()  # noqa: SLF001
 
-    # The scheduler is still alive (no exception propagated).
-    # Transport was never called because the error happened
-    # before send.
     assert transport.sent == []
+
+
+def test_cache_limit_triggers_trim() -> None:
+    a1 = _article(id="1")
+    cache = FakeCache(cached=[a1])
+    scheduler = _make_scheduler(
+        listener=FakeListener(articles=(a1,)),
+        cache=cache,
+        cache_limit=5,
+    )
+    scheduler._tick()  # noqa: SLF001
+    assert cache.trim_calls == [5]
+
+
+def test_no_cache_limit_skips_trim() -> None:
+    a1 = _article(id="1")
+    cache = FakeCache(cached=[a1])
+    scheduler = _make_scheduler(
+        listener=FakeListener(articles=(a1,)),
+        cache=cache,
+    )
+    scheduler._tick()  # noqa: SLF001
+    assert cache.trim_calls == []

--- a/tests/transports/test_telegram.py
+++ b/tests/transports/test_telegram.py
@@ -30,6 +30,7 @@ class FakeHttpClient:
         self._post_response = post_response or {"ok": True}
         self._raise_on_post = raise_on_post
         self.post_calls: list[dict[str, Any]] = []
+        self.closed = False
 
     def get(self, url: str) -> bytes:
         raise NotImplementedError
@@ -44,6 +45,15 @@ class FakeHttpClient:
         if self._raise_on_post is not None:
             raise self._raise_on_post
         return self._post_response
+
+    def close(self) -> None:
+        self.closed = True
+
+    def __enter__(self) -> "FakeHttpClient":
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        self.close()
 
 
 def test_send_single_article() -> None:
@@ -179,6 +189,15 @@ def test_send_partial_failure() -> None:
                 raise HttpClientError("fail")
             return {"ok": True}
 
+        def close(self) -> None:
+            pass
+
+        def __enter__(self) -> "FailOnSecondHttpClient":
+            return self
+
+        def __exit__(self, *_: Any) -> None:
+            self.close()
+
     transport = TelegramBotTransport(
         token=_TOKEN,
         to=_CHAT_ID,
@@ -190,6 +209,59 @@ def test_send_partial_failure() -> None:
     failed = transport.send(a1, a2, a3)
     assert len(failed) == 1
     assert failed[0] == a2
+
+
+def test_default_template_html_escapes_article_fields() -> None:
+    http = FakeHttpClient()
+    transport = TelegramBotTransport(
+        token=_TOKEN,
+        to=_CHAT_ID,
+        http_client=http,
+    )
+    article = _article(
+        title="Ampersand & <script>",
+        text="body with <b> tags & chars",
+    )
+    transport.send(article)
+    text = http.post_calls[0]["data"]["text"]
+    assert "Ampersand &amp; &lt;script&gt;" in text
+    assert "body with &lt;b&gt; tags &amp; chars" in text
+    assert "<script>" not in text
+
+
+def test_custom_template_also_escapes_variables() -> None:
+    http = FakeHttpClient()
+    transport = TelegramBotTransport(
+        token=_TOKEN,
+        to=_CHAT_ID,
+        template="<b>{{ TITLE }}</b>",
+        http_client=http,
+    )
+    transport.send(_article(title="A & B"))
+    text = http.post_calls[0]["data"]["text"]
+    assert text == "<b>A &amp; B</b>"
+
+
+def test_close_closes_http_client() -> None:
+    http = FakeHttpClient()
+    transport = TelegramBotTransport(
+        token=_TOKEN,
+        to=_CHAT_ID,
+        http_client=http,
+    )
+    transport.close()
+    assert http.closed is True
+
+
+def test_context_manager_closes_http_client() -> None:
+    http = FakeHttpClient()
+    with TelegramBotTransport(
+        token=_TOKEN,
+        to=_CHAT_ID,
+        http_client=http,
+    ):
+        pass
+    assert http.closed is True
 
 
 def test_repr() -> None:

--- a/tmfeed/config.yml
+++ b/tmfeed/config.yml
@@ -1,46 +1,43 @@
 ---
-cache:
-  type: 'files'
-schedulers:
-  - listener:
-      type: 'rss'
-      params:
-        url: 'https://habr.com/ru/rss/articles/?fl=ru'
-    transport:
-      type: 'telegram_bot'
-      params:
-        token: '__FEEDFORBOT_TOKEN__'
-        to: '@tmfeed'
-        template: |-
-          <b>{{ TITLE }}</b> #habr
-          {{ ID }}
-          <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
-          <b>Author</b>: <a href="https://habr.com/users/{{ AUTHORS[0] }}">{{ AUTHORS[0] }}</a>
-  - listener:
-      type: 'rss'
-      params:
-        url: 'https://habr.com/ru/rss/news/?fl=ru'
-    transport:
-      type: 'telegram_bot'
-      params:
-        token: '__FEEDFORBOT_TOKEN__'
-        to: '@tmfeed'
-        template: |-
-          <b>{{ TITLE }}</b> #habr
-          {{ ID }}
-          <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
-  - listener:
-      type: 'rss'
-      params:
-        url: 'http://www.opennet.ru/opennews/opennews_all.rss'
-    transport:
-      type: 'telegram_bot'
-      params:
-        token: '__FEEDFORBOT_TOKEN__'
-        to: '@tmfeed'
-        disable_web_page_preview: yes
-        template: |-
-          <b>{{ TITLE }}</b> #opennet
-          {{ URL }}
+- listener:
+    type: 'rss'
+    params:
+      url: 'https://habr.com/ru/rss/articles/?fl=ru'
+  transport:
+    type: 'telegram_bot'
+    params:
+      token: '__FEEDFORBOT_TOKEN__'
+      to: '@tmfeed'
+      template: |-
+        <b>{{ TITLE }}</b> #habr
+        {{ ID }}
+        <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
+        <b>Author</b>: <a href="https://habr.com/users/{{ AUTHORS[0] }}">{{ AUTHORS[0] }}</a>
+- listener:
+    type: 'rss'
+    params:
+      url: 'https://habr.com/ru/rss/news/?fl=ru'
+  transport:
+    type: 'telegram_bot'
+    params:
+      token: '__FEEDFORBOT_TOKEN__'
+      to: '@tmfeed'
+      template: |-
+        <b>{{ TITLE }}</b> #habr
+        {{ ID }}
+        <b>Tags</b>: {% for category in CATEGORIES %}{{ category }}{{ ", " if not loop.last else "" }}{% endfor %}
+- listener:
+    type: 'rss'
+    params:
+      url: 'http://www.opennet.ru/opennews/opennews_all.rss'
+  transport:
+    type: 'telegram_bot'
+    params:
+      token: '__FEEDFORBOT_TOKEN__'
+      to: '@tmfeed'
+      disable_web_page_preview: yes
+      template: |-
+        <b>{{ TITLE }}</b> #opennet
+        {{ URL }}
 
-          {{ TEXT }}
+        {{ TEXT }}

--- a/tmfeed/deploy.yml
+++ b/tmfeed/deploy.yml
@@ -46,18 +46,18 @@
         state: directory
         mode: "0755"
 
-    - name: Create feedforbot data directory
+    - name: Create redis data directory
       file:
-        path: "{{ feedforbot_dir }}/feedforbot_data"
+        path: "{{ feedforbot_dir }}/redis_data"
         state: directory
         owner: "999"
         group: "999"
         mode: "0755"
       become: true
 
-    - name: Fix feedforbot_data file ownership
+    - name: Fix redis_data file ownership
       become: true
-      shell: chown -R 999:999 "{{ feedforbot_dir }}/feedforbot_data"
+      shell: chown -R 999:999 "{{ feedforbot_dir }}/redis_data"
       changed_when: false
 
     - name: Deploy config.yml
@@ -80,16 +80,32 @@
         mode: "0644"
         content: |
           services:
+            redis:
+              image: redis:7-alpine
+              container_name: feedforbot-redis
+              restart: always
+              volumes:
+                - ./redis_data:/data
+              command: ["redis-server", "--save", "60", "1", "--appendonly", "no"]
+              healthcheck:
+                test: ["CMD", "redis-cli", "ping"]
+                interval: 10s
+                timeout: 3s
+                retries: 3
+                start_period: 5s
+
             feedforbot:
               image: {{ feedforbot_image }}
               container_name: feedforbot
               restart: always
+              depends_on:
+                redis:
+                  condition: service_healthy
               volumes:
                 - ./config.yml:/config.yml:ro
-                - ./feedforbot_data:/home/appuser/.feedforbot/
-              command: -v --healthcheck-port 8080 {{ ('--sentry ' + feedforbot_sentry) if feedforbot_sentry != '' else '' }} /config.yml
+              command: -v --cache-dsn redis://redis:6379/0 --healthcheck-port 8080 {{ ('--sentry ' + feedforbot_sentry) if feedforbot_sentry != '' else '' }} /config.yml
               healthcheck:
-                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/')"]
+                test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')"]
                 interval: 30s
                 timeout: 5s
                 retries: 3

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "5.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a5/ae/136395dfbfe00dfc94da3f3e136d0b13f394cba8f4841120e34226265780/async_timeout-5.0.1.tar.gz", hash = "sha256:d9321a7a3d5a6a5e187e824d2fa0793ce379a202935782d555d6e9d2735677d3", size = 9274, upload-time = "2024-11-06T16:41:39.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ba/e2081de779ca30d473f21f5b30e0e737c438205440784c7dfc81efc2b029/async_timeout-5.0.1-py3-none-any.whl", hash = "sha256:39e3809566ff85354557ec2398b55e096c8364bacac9405a7a1fa429e77fe76c", size = 6233, upload-time = "2024-11-06T16:41:37.9Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -288,6 +297,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fakeredis"
+version = "2.35.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "redis" },
+    { name = "sortedcontainers" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/50/b748233c02fa77e5105238190cc9bb58b852eb1c8b1d0763230d3a5b745a/fakeredis-2.35.1.tar.gz", hash = "sha256:5bae5eba7b9d93cb968944ac40936373cf2397ff71667d4b595df65c3d2e413f", size = 189118, upload-time = "2026-04-12T17:05:58.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/27/b8b057a23f7777177e92d3a602fd866751b6b45014964548997e92e048fd/fakeredis-2.35.1-py3-none-any.whl", hash = "sha256:67d97e11f562b7870e11e5c30cf182270bfb2dd37f6707dba47cc6d91628d1b9", size = 129678, upload-time = "2026-04-12T17:05:56.86Z" },
+]
+
+[[package]]
 name = "feedforbot"
 version = "0.1.0"
 source = { editable = "." }
@@ -305,12 +328,14 @@ dependencies = [
 cli = [
     { name = "click" },
     { name = "pyyaml" },
+    { name = "redis" },
     { name = "sentry-sdk" },
     { name = "structlog" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "fakeredis" },
     { name = "feedforbot", extra = ["cli"] },
     { name = "freezegun" },
     { name = "mypy" },
@@ -335,6 +360,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1,<4" },
     { name = "pydantic", specifier = ">=2.0,<3" },
     { name = "pyyaml", marker = "extra == 'cli'", specifier = ">=6.0,<7" },
+    { name = "redis", marker = "extra == 'cli'", specifier = ">=5,<6" },
     { name = "sentry-sdk", marker = "extra == 'cli'", specifier = ">=2.0,<3" },
     { name = "structlog", marker = "extra == 'cli'", specifier = ">=24.1" },
 ]
@@ -342,6 +368,7 @@ provides-extras = ["cli"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "fakeredis", specifier = ">=2,<3" },
     { name = "feedforbot", extras = ["cli"] },
     { name = "freezegun", specifier = ">=1.5" },
     { name = "mypy", specifier = ">=1.15,<2" },
@@ -851,6 +878,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -973,6 +1012,19 @@ wheels = [
 ]
 
 [[package]]
+name = "redis"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
+]
+
+[[package]]
 name = "respx"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1035,6 +1087,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `--cache-dsn` CLI flag with `file:` / `memory:` / `redis://` backends, `RedisCache` implementation, and per-scheduler `cache_limit`
- Flattens the YAML schedulers config (removes `cache:` / `schedulers:` wrappers; cache backend moved to the new CLI flag) and redesigns `CacheProtocol` around `is_populated` / `known_ids` / `add` / `trim`
- Restricts healthcheck to `/health` with configurable `--healthcheck-host` (default `127.0.0.1`); adds graceful `SIGTERM` / `SIGINT` shutdown; Telegram `429` flood-wait retry; HTML-autoescape for templates; atomic file cache writes with corrupt-tolerant load; token masking on error paths
- Updates `tmfeed/` deploy to run Redis alongside `feedforbot` in docker-compose and documents the layout in README

See `CHANGELOG.md` for the full list of Added / Changed / Fixed entries.

## Test plan

- [x] `uv run ruff check feedforbot tests`
- [x] `uv run ruff format --check feedforbot tests`
- [x] `uv run mypy --pretty -p feedforbot`
- [x] `uv run pytest -q` (102 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)